### PR TITLE
Remove obsolete workaround call

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -51,7 +51,6 @@ ARCH_ARM_HAVE_TLS_REGISTER := true
 ARCH_ARM_HAVE_32_BYTE_CACHE_LINES := true
 #ARCH_ARM_USE_NON_NEON_MEMCPY := true
 #ARCH_LIBPNG_NO_NEON := true
-NEED_WORKAROUND_CORTEX_A9_745320 := true
 
 # Boot/Recovery image settings  
 BOARD_KERNEL_CMDLINE := androidboot.selinux=permissive


### PR DESCRIPTION
This call was available dalvik before ART took over.
I couldnt find this workaround anymore after the removal of DALVIK so it seems this no longer works and can safely be removed
