### PR TITLE
correctly set the physical pixels density

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -1,7 +1,7 @@
 #
 # system.prop for tf300
 #
-ro.carrier=wifi-onlyou
+ro.carrier=wifi-only
 #configure the physical pixels density
 ro.sf.lcd_density=150
 

--- a/system.prop
+++ b/system.prop
@@ -1,8 +1,9 @@
 #
 # system.prop for tf300
 #
-ro.carrier=wifi-only
-ro.sf.lcd_density=160
+ro.carrier=wifi-onlyou
+#configure the physical pixels density
+ro.sf.lcd_density=150
 
 ro.ethernet.interface=eth0
 ro.ethernet.autoEnable=yes


### PR DESCRIPTION
the dpi should be configured correctly so screen elements are proerly sized
Horizontal resolution: 1280 pixels 
Vertical resolution:  800 pixels 
Diagonal:  10.1 inches (25.65cm)
Aspect ratio: 16:10
Display size: 8.56" × 5.35" = 45.85in² (21.75cm × 13.6cm = 295.79cm²) at 149.45 PPI, 0.17mm dot pitch, 22335 PPI²
