### PR TITLE
Remove ARCH_ARM_HAVE_32_BYTE_CACHE_LINES and ARCH_ARM_USE_NON_NEON_ME…

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -48,8 +48,6 @@ TARGET_ARCH := arm
 TARGET_ARCH_VARIANT := armv7-a-neon
 TARGET_CPU_VARIANT := cortex-a9
 ARCH_ARM_HAVE_TLS_REGISTER := true
-ARCH_ARM_HAVE_32_BYTE_CACHE_LINES := true
-#ARCH_ARM_USE_NON_NEON_MEMCPY := true
 #ARCH_LIBPNG_NO_NEON := true
 
 # Boot/Recovery image settings  


### PR DESCRIPTION
…MCPY

These options have been removed since https://android.googlesource.com/platform/bionic/+/306a3538254ed8272ff3d04bcb724d87af7423d1
