### PR TITLE
Remove TARGET_CPU_SMP

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -43,7 +43,6 @@ TARGET_BOARD_PLATFORM := tegra
 
 TARGET_CPU_ABI := armeabi-v7a
 TARGET_CPU_ABI2 := armeabi
-TARGET_CPU_SMP := true
 TARGET_ARCH := arm
 TARGET_ARCH_VARIANT := armv7-a-neon
 TARGET_CPU_VARIANT := cortex-a9


### PR DESCRIPTION
No longer a valid option since commit https://android.googlesource.com/platform/bionic/+/bfbf7a4300ab5cd6334212f701e47ea449456048
