### PR TITLE
Remove unused recovery options

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -112,11 +112,8 @@ BOARD_HARDWARE_CLASS := device/asus/tf300t/cmhw/
 # Recovery Options
 #BOARD_CUSTOM_BOOTIMG_MK := device/asus/tf300t/recovery/recovery.mk
 BOARD_HAS_NO_SELECT_BUTTON := true
-BOARD_HAS_LARGE_FILESYSTEM := true
-BOARD_HAS_SDCARD_INTERNAL := true
 TARGET_RECOVERY_FSTAB := device/asus/tf300t/ramdisk/fstab.cardhu
 RECOVERY_FSTAB_VERSION := 2
-BOARD_RECOVERY_SWIPE := true
 
 
 ARCH_ARM_HIGH_OPTIMIZATION := true


### PR DESCRIPTION
These have been removed a long time ago:

BOARD_HAS_LARGE_FILESYSTEM
BOARD_HAS_SDCARD_INTERNAL
BOARD_RECOVERY_SWIPE
