### PR TITLE
Art: Maximize optimization potential

### DIFF
--- a/device_tf300t.mk
+++ b/device_tf300t.mk
@@ -129,7 +129,7 @@ PRODUCT_PROPERTY_OVERRIDES += \
 # Aggresively optimize art for performance
 PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.dex2oat-flags=--no-watch-dog \
-    dalvik.vm.dex2oat-swap=false
+    dalvik.vm.dex2oat-swap=false \
     pm.dexopt.bg-dexopt=everything-profile \
     pm.dexopt.ab-ota=everything-profile \
     pm.dexopt.nsys-library=everything-profile \

--- a/device_tf300t.mk
+++ b/device_tf300t.mk
@@ -126,10 +126,16 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.epad.model=TF300T \
     ro.product.model=TF300T
-#misc
+# Aggresively optimize art for performance
 PRODUCT_PROPERTY_OVERRIDES += \
     dalvik.vm.dex2oat-flags=--no-watch-dog \
     dalvik.vm.dex2oat-swap=false
+    pm.dexopt.bg-dexopt=everything-profile \
+    pm.dexopt.ab-ota=everything-profile \
+    pm.dexopt.nsys-library=everything-profile \
+    pm.dexopt.shared-apk=everything-profile \
+    pm.dexopt.forced-dexopt=everything-profile \
+    pm.dexopt.core-app=everything-profile
 
 # media files
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
Since android 7.1 the build system configures art to run in JIT mode which gives us
the possibility of creating profiled builds which can run faster.

Override the default settings and force everything-profile for everything to make sure 
we get every last drop of performance.