### PR TITLE
Update fstab.cardhu

### DIFF
--- a/ramdisk/fstab.cardhu
+++ b/ramdisk/fstab.cardhu
@@ -1,22 +1,20 @@
 # Android fstab file.
-#<src> <mnt_point>  <type> <mnt_flags>  <fs_mgr_flags>
+#<src>                                           <mnt_point>    <type>    <mnt_flags and options>                               <fs_mgr_flags>
 # The filesystem that contains the filesystem checker binary (typically /system) cannot
 # specify MF_CHECK, and must come before any filesystems that do specify MF_CHECK
 
-# Init mount points
-/dev/block/mmcblk0p1	/system	ext4	ro	wait
-/dev/block/mmcblk0p2	/cache	ext4	noatime,nosuid,nodev,nomblk_io_submit,errors=panic	wait
-/dev/block/mmcblk0p8	/data	f2fs	noatime,nosuid,nodev,errors=panic	                wait,encryptable=footer
-/dev/block/mmcblk0p8	/data	ext4	noatime,nosuid,nodev,nomblk_io_submit,errors=panic	wait,encryptable=footer
+/dev/block/platform/sdhci-tegra.3/by-name/USP    /staging       emmc      defaults                                              defaults
+/dev/block/mmcblk0p10                            /recovery      emmc      defaults                                              defaults
+/dev/block/mmcblk0p9                             /boot          emmc      defaults                                              defaults
+/dev/block/platform/sdhci-tegra.3/by-name/APP    /system        ext4      ro,barrier=1                                          wait
+/dev/block/platform/sdhci-tegra.3/by-name/CAC    /cache         ext4      noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panicc    wait,check,formattable
+/dev/block/platform/sdhci-tegra.3/by-name/UDA    /data          f2fs      noatime,nosuid,nodev,errors=panic                     wait,check,encryptable=footer,formattable,length=-16384
+/dev/block/platform/sdhci-tegra.3/by-name/UDA    /data          ext4      noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panic    wait,check,encryptable=footer,formattable,length=-16384
+/dev/block/platform/sdhci-tegra.3/by-name/PER    /btmac         vfat      ro,shortname=lower,uid=1000,gid=0,dmask=227,fmask=337 wait
+/dev/block/platform/sdhci-tegra.3/by-name/MSC    /misc          emmc      defaults                                              defaults
+/dev/block/platform/sdhci-tegra.3/by-name/CRA    /cra           emmc      defaults                                              defaults
+/dev/block/platform/sdhci-tegra.3/by-name/YTU    /ytu           emmc      defaults                                              defaults
 
-# Vold mount points
-/devices/platform/sdhci-tegra.0/mmc_host* auto  auto defaults voldmanaged=sdcard1:auto,encryptable=userdata
-/devices/platform/tegra-ehci.2/usb* auto auto defaults voldmanaged=usb:auto,encryptable=userdata
-
-# Recovery only mount points
-/dev/block/mmcblk1p1	/external_sd		auto defaults recoveryonly
-/dev/block/mmcblk0p3	/misc			emmc defaults recoveryonly
-/dev/block/mmcblk0p4	/staging		emmc defaults recoveryonly
-/dev/block/mmcblk0p5	/btmac			auto defaults recoveryonly
-/dev/block/platform/sdhci-tegra.3/by-name/LNX           /boot               emmc      defaults                                                      defaults
-/dev/block/platform/sdhci-tegra.3/by-name/SOS           /recovery           emmc      defaults                                                      defaults
+/devices/platform/sdhci-tegra.0/mmc_host*        auto           auto      defaults                                              voldmanaged=sdcard1:auto,encryptable=userdata
+/devices/platform/sdhci-tegra.2/mmc_host*        auto           auto      defaults                                              voldmanaged=sdcard2:auto,encryptable=userdata
+/devices/platform/tegra-ehci.2/usb*              auto           auto      defaults                                              voldmanaged=usb:auto,encryptable=userdata

--- a/ramdisk/fstab.cardhu
+++ b/ramdisk/fstab.cardhu
@@ -7,7 +7,7 @@
 /dev/block/mmcblk0p10                            /recovery      emmc      defaults                                              defaults
 /dev/block/mmcblk0p9                             /boot          emmc      defaults                                              defaults
 /dev/block/platform/sdhci-tegra.3/by-name/APP    /system        ext4      ro,barrier=1                                          wait
-/dev/block/platform/sdhci-tegra.3/by-name/CAC    /cache         ext4      noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panicc    wait,check,formattable
+/dev/block/platform/sdhci-tegra.3/by-name/CAC    /cache         ext4      noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panic    wait,check,formattable
 /dev/block/platform/sdhci-tegra.3/by-name/UDA    /data          f2fs      noatime,nosuid,nodev,errors=panic                     wait,check,encryptable=footer,formattable,length=-16384
 /dev/block/platform/sdhci-tegra.3/by-name/UDA    /data          ext4      noatime,nosuid,nodev,barrier=1,data=ordered,nomblk_io_submit,noauto_da_alloc,errors=panic    wait,check,encryptable=footer,formattable,length=-16384
 /dev/block/platform/sdhci-tegra.3/by-name/PER    /btmac         vfat      ro,shortname=lower,uid=1000,gid=0,dmask=227,fmask=337 wait


### PR DESCRIPTION
* update to by-name format
* lnx and sos do not exist on tf201, replaced with 
  mmcblk0p9 and mmcblk0p10, NOTE i do not know
  which is boot and recovery
* cra = crashdumps, i think its unused
* ytu is drm firmware, this was wiped on unlock
  maybe it can be restored?
* btmac changed to vfat, this needs testing to confirm everything is working
* added sdhci-tegra.2/mmc_host, maybe thats the dock?
* updated mount and fs flags to current standards

Discussion:
* We can switch to "nobarrier" and gain performance on ext4 at the risk of data loss if the system crashes
* We can switch to "data=writeback" and gain performance on ext4 at the risk of data loss if the system crashes
